### PR TITLE
Restore xmldom to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "commonjs"
   ],
   "dependencies": {
-    "lodash": "^4.16.4"
+    "lodash": "^4.16.4",
+    "xmldom": "^0.1.22"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
xmldom is [inserted by gulpfile](https://github.com/mo4islona/node-blockly/blob/765a6349fd1f0a9d31664e427569a4832a499af5/gulpfile.js#L31) into the `lib/*` files.