### PR TITLE
Drop about 25 megs from package size by excluding demos

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+blockly/demos/


### PR DESCRIPTION
Since most people consuming this package via NPM probably don't need the blockly `demos` folder, leave it out of the NPM package. This drops package size on disk from ~30mb to around 3mb.