### PR TITLE
Replacing xmldom with jsdom & xmlshim

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,17 +6,7 @@ var gulp = require('gulp'),
     insert = require('gulp-insert');
 
 var document = `
-var document = {
-   createTextNode: function() {},
-   createElement: function() {
-      return {
-        hasChildNodes: function() {},
-        hasAttributes: function() {},
-        setAttribute: function() {},
-        appendChild: function() {}
-      }
-   }
-}
+var document = (new (require('jsdom').JSDOM)()).window.document;
 `;
 
 var _browserRename = function(path) {
@@ -27,8 +17,12 @@ gulp.task('blockly', function() {
   return gulp.src('blockly/blockly_compressed.js')
       .pipe(replace(/goog\.global\s*=\s*this;/, 'goog.global=global;'))
       .pipe(insert.wrap(`
-      var DOMParser = require("xmldom").DOMParser; 
-      var XMLSerializer = require("xmldom").XMLSerializer; 
+      var JSDOM = require('jsdom').JSDOM;
+      var window = (new JSDOM()).window;
+      var DOMParser = window.DOMParser;
+      var XMLSerializer = require('xmlserializer');
+      // var DOMParser = require("xmldom").DOMParser; 
+      // var XMLSerializer = require("xmldom").XMLSerializer; 
       ${document}
       module.exports = (function(){`,
           //....ORIGINAL CODE....

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,9 @@ gulp.task('blockly', function() {
       var JSDOM = require('jsdom').JSDOM;
       var window = (new JSDOM()).window;
       var DOMParser = window.DOMParser;
-      var XMLSerializer = require('xmlserializer');
+      var xmlshim = require('xmlshim');
+      var XMLSerializer = xmlshim.XMLSerializer;
+      var DOMParser = xmlshim.DOMParser; 
       // var DOMParser = require("xmldom").DOMParser; 
       // var XMLSerializer = require("xmldom").XMLSerializer; 
       ${document}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "commonjs"
   ],
   "dependencies": {
-    "xmldom": "^0.1.22"
+    "jsdom": "^11.3.0",
+    "xmldom": "^0.1.22",
+    "xmlserializer": "^0.6.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "jsdom": "^11.3.0",
     "xmldom": "^0.1.22",
-    "xmlserializer": "^0.6.0"
+    "xmlshim": "^0.2.1"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
This should solve #15 

The test suite runs except for the `domToText` and `domToPrettyText`, which I'm not sure what's failing. To me, it seems the strategy of using `replace` to clear the produced object is inefficient, and I would only check if the resulting string's length is `>0`, but I'd like to have your opinion before modifying the tests.